### PR TITLE
Blame mode

### DIFF
--- a/plugin/github_url.rb
+++ b/plugin/github_url.rb
@@ -8,6 +8,7 @@ class GithubUrl
   end
 
   def generate(*args)
+    status = blame_mode?(args) ? 'blame' : 'blob'
     host, path = parse_remote_origin
     revision   = args.first || current_head
     revision   = to_revision(revision) if is_branch?(revision)
@@ -16,10 +17,14 @@ class GithubUrl
     user = trimmed_path.split("/").first
     repo = trimmed_path.split("/").last
 
-    File.join("#{scheme}://#{host}", user, repo, 'blob', revision, "#{file_path}#{line_anchor}")
+    File.join("#{scheme}://#{host}", user, repo, status, revision, "#{file_path}#{line_anchor}")
   end
 
   private
+
+  def blame_mode?(args)
+    args.delete('-b') || args.delete('--blame')
+  end
 
   def parse_remote_origin
     if remote_origin =~ /^(http|https|ssh):\/\//
@@ -42,7 +47,7 @@ class GithubUrl
     full_path =
       if @file_name.include?(current_dir)
         @file_name
-      else 
+      else
         File.join(current_dir, @file_name)
       end
     full_path.gsub(/^#{repository_root}/, "")

--- a/plugin/open-github.vim
+++ b/plugin/open-github.vim
@@ -17,6 +17,7 @@ class GithubUrl
   end
 
   def generate(*args)
+    status = blame_mode?(args) ? 'blame' : 'blob'
     host, path = parse_remote_origin
     revision   = args.first || current_head
     revision   = to_revision(revision) if is_branch?(revision)
@@ -25,10 +26,14 @@ class GithubUrl
     user = trimmed_path.split("/").first
     repo = trimmed_path.split("/").last
 
-    File.join("#{scheme}://#{host}", user, repo, 'blob', revision, "#{file_path}#{line_anchor}")
+    File.join("#{scheme}://#{host}", user, repo, status, revision, "#{file_path}#{line_anchor}")
   end
 
   private
+
+  def blame_mode?(args)
+    args.delete('-b') || args.delete('--blame')
+  end
 
   def parse_remote_origin
     if remote_origin =~ /^(http|https|ssh):\/\//
@@ -51,7 +56,7 @@ class GithubUrl
     full_path =
       if @file_name.include?(current_dir)
         @file_name
-      else 
+      else
         File.join(current_dir, @file_name)
       end
     full_path.gsub(/^#{repository_root}/, "")

--- a/spec/plugin/github_url_spec.rb
+++ b/spec/plugin/github_url_spec.rb
@@ -16,6 +16,13 @@ describe GithubUrl do
     let(:github_repo_url) { "https://github.com/#{user}/vim-open-github/blob/#{revision}#{target_file_path}" }
     let(:remote_origin) { "git@github.com:/#{user}/vim-open-github.git" }
 
+    let(:user) do
+      remote = `git config remote.origin.url`
+      if res = remote.match(/github.com[\/:]([\w\d])/)
+        res[1]
+      end
+    end
+
     before do
       allow(github_url).to receive(:repository_root).and_return(repo_root)
       allow(github_url).to receive(:remote_origin).and_return(remote_origin)

--- a/spec/plugin/github_url_spec.rb
+++ b/spec/plugin/github_url_spec.rb
@@ -87,11 +87,23 @@ describe GithubUrl do
       end
     end
 
-    context 'given argument' do
+    context 'given arguments' do
       subject { github_url.generate(version) }
       let(:version) { 'v4.2.3' }
 
       it { is_expected.to eq("https://github.com/#{user}/vim-open-github/blob/#{version}#{target_file_path}#L1") }
+
+      context 'when given the -b flag' do
+        subject { github_url.generate('-b', version) }
+
+        it { is_expected.to eq("https://github.com/#{user}/vim-open-github/blame/#{version}#{target_file_path}#L1") }
+      end
+
+      context 'when given the --blame flag' do
+        subject { github_url.generate('--blame', version) }
+
+        it { is_expected.to eq("https://github.com/#{user}/vim-open-github/blame/#{version}#{target_file_path}#L1") }
+      end
     end
   end
 end


### PR DESCRIPTION
This will use `blame` instead of `blob` in the Github URL ([like this](https://github.com/k0kubun/vim-open-github/blame/master/plugin/github_url.rb)) when called with the `-b` or `--blame` flags. Let me know if you're down with this / if I need to fix anything.
